### PR TITLE
added lock to block patient from logging back to staff view without e…

### DIFF
--- a/client/templates/client_appointment_detail_status_tab.html
+++ b/client/templates/client_appointment_detail_status_tab.html
@@ -21,17 +21,18 @@
 		{{/ionItem}}
 		--}}
 		<!--<div class="navbar_normal_buttons">
-		{{> toggle_button}}
+
 		</div>-->
-		<!--{{> toggle_button}}-->
+
 	{{/contentFor}}
 
-	{{#contentFor "headerButtonRight"}}
-		{{!--
-		{{> atNavButton}}
-		--}}
-		{{> toggle_button}}
-	{{/contentFor}}
+    {{#contentFor "headerButtonRight"}}
+    {{!--
+    {{> atNavButton}}
+    --}}
+        <!--{{> toggle_button}}-->
+        {{> toggle_button_for_patient}}
+    {{/contentFor}}
 
 
 	{{#contentFor "headerTitle"}}

--- a/client/templates/staff_passcode_enter.html
+++ b/client/templates/staff_passcode_enter.html
@@ -1,0 +1,17 @@
+<template name = "staff_passcode_enter">
+    <!--{{#ionModal title="ENTER STAFF PASSCODE"}}-->
+
+        <!--<label class="item item-input">-->
+            <!--<input type="password" placeholder="Password" id="password">-->
+        <!--</label>-->
+
+        <!--{{> loginButtons}}-->
+    <!--{{/ionModal}}-->
+        <div class="list">
+            <label class="item item-input">
+                <input type="password" placeholder="passcode" id="passcode">
+            </label>
+            <label style="color: red" id="status_bar">
+            </label>
+        </div>
+</template>

--- a/client/templates/staff_passcode_enter.js
+++ b/client/templates/staff_passcode_enter.js
@@ -1,0 +1,5 @@
+Template.staff_passcode_enter.events({
+	"click .login_button" : function(){
+		console.log("LOL!");
+	}
+});

--- a/client/templates/toggle_button_for_patient.html
+++ b/client/templates/toggle_button_for_patient.html
@@ -1,0 +1,14 @@
+<template name="toggle_button_for_patient">
+
+    <!--<button class="button button-positive patient_switch">
+        Switch to Patient
+    </button>
+    <button class="button button-assertive staff_switch">
+        Switch to Staff
+    </button>-->
+    <button id="staff_view_with_passcode" style="height: 62px; padding: 0px;" class="button button-light staff_switch">
+        <img src="settings_large.png"/>
+    </button>
+
+
+</template>

--- a/client/templates/toggle_button_for_patient.js
+++ b/client/templates/toggle_button_for_patient.js
@@ -1,0 +1,35 @@
+Template.toggle_button_for_patient.events({
+	"click #staff_view_with_passcode" : function(e){
+		IonPopup.show({
+			title: 'ENTER PASSCODE',
+			templateName : "staff_passcode_enter",
+			buttons : [
+				{
+					text:'Sign In',
+					type:'button-positive',
+					onTap:function(){
+						var passcode = $("#passcode").val();
+
+						if (Meteor.user().profile.in_app_passcode == passcode) {
+							IonPopup.close();
+							//IonModal.close();
+							//Router.go("/control_modal");
+							IonModal.open("control_modal");
+						} else {
+							$("#status_bar").text("Login forbidden");
+							console.log(Meteor.user().profile.name + " attempted login to staff view");
+						}
+					}
+				},
+				{
+					text: 'Close',
+					type: 'button-positive',
+					onTap: function(){
+						IonPopup.close();
+					}
+				}
+			]
+		});
+	}
+
+});

--- a/server/server_startup.js
+++ b/server/server_startup.js
@@ -20,7 +20,8 @@ function startup_data(){
 				phone_number : "555-666-7777",
 				dob:new Date("12 Jun 1990"),
 				mrn:"16182369",
-				gender:"male"},
+				gender:"male",
+				in_app_passcode:"12345"},
 			user_type:"patient"
 		});
 
@@ -28,11 +29,12 @@ function startup_data(){
 			email:"ella.amaryllis@fake.com",
 			password:"testpatient",
 			profile :{
-				name: "Ella Amaryllis",
+				name: "Ellaaaa Amaryllis",
 				phone_number : "555-111-2222",
 				dob:new Date("1 Aug 1990"),
 				mrn:"12983102",
-				gender:"female"},
+				gender:"female",
+				in_app_passcode:"12345"},
 			user_type:"patient"
 		});
 		
@@ -44,7 +46,8 @@ function startup_data(){
 				phone_number : "555-222-3333",
 				dob:new Date("3 Feb 1986"),
 				mrn:"36193716",
-				gender:"male"},
+				gender:"male",
+				in_app_passcode:"12345"},
 			user_type:"patient"
 		});
 		
@@ -56,7 +59,8 @@ function startup_data(){
 				phone_number : "555-777-8888",
 				dob:new Date("27 Jan 1970"),
 				mrn:"81730183",
-				gender:"male"},
+				gender:"male",
+				in_app_passcode:"12345"},
 			user_type:"patient"
 		});
 		
@@ -66,7 +70,8 @@ function startup_data(){
 			password:"demo",
 			profile : {
 				name: "Gregory House",
-				phone_number : "555-888-9999"}, 
+				phone_number : "555-888-9999",
+				in_app_passcode:"12345"},
 			user_type: "staff"
 		});
 		
@@ -75,7 +80,8 @@ function startup_data(){
 			password:"teststaff",
 			profile : {
 				name: "Polly Robinson",
-				phone_number : "555-888-9999"}, 
+				phone_number : "555-888-9999",
+				in_app_passcode:"12345"},
 			user_type: "staff"
 		});
 


### PR DESCRIPTION
Added a lock on top of "client_status_tab" view to prevent patient from logging back to staff view without entering passcode. 
When the attempt of logging out of patient view is made, a popup window asking for passcode will show up. Only when the passcode is correct, will the user be able to see the control panel, which will only be allowed to be seen by staff. 
